### PR TITLE
Small tweaks to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "nan": "^2.17.0"
       },
       "devDependencies": {
-        "tree-sitter-c": "git://github.com/tree-sitter/tree-sitter-c.git",
-        "tree-sitter-cli": "^0.20.7"
+        "tree-sitter-c": "^0.20.6",
+        "tree-sitter-cli": "^0.20.8"
       }
     },
     "node_modules/nan": {
@@ -23,10 +23,10 @@
     },
     "node_modules/tree-sitter-c": {
       "version": "0.20.6",
-      "resolved": "git+ssh://git@github.com/tree-sitter/tree-sitter-c.git#a2b7bac3b313efbaa683d9a276ff63cdc544d960",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.20.6.tgz",
+      "integrity": "sha512-YosSBUOJ21j4mb7SmDmKI3QYQb7ANj55u2RTlj0XHQ6gFoLkpHzJDGvVK4zlbvqyPXA0u62LdhTwbLvYzHWcdw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "nan": "^2.17.0"
       }
@@ -49,9 +49,10 @@
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "tree-sitter-c": {
-      "version": "git+ssh://git@github.com/tree-sitter/tree-sitter-c.git#a2b7bac3b313efbaa683d9a276ff63cdc544d960",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.20.6.tgz",
+      "integrity": "sha512-YosSBUOJ21j4mb7SmDmKI3QYQb7ANj55u2RTlj0XHQ6gFoLkpHzJDGvVK4zlbvqyPXA0u62LdhTwbLvYzHWcdw==",
       "dev": true,
-      "from": "tree-sitter-c@git://github.com/tree-sitter/tree-sitter-c.git",
       "requires": {
         "nan": "^2.17.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "nan": "^2.17.0"
   },
   "devDependencies": {
-    "tree-sitter-c": "git://github.com/tree-sitter/tree-sitter-c.git",
-    "tree-sitter-cli": "^0.20.7"
+    "tree-sitter-c": "^0.20.6",
+    "tree-sitter-cli": "^0.20.8"
   },
   "scripts": {
+    "build": "tree-sitter generate && node-gyp build",
+    "parse": "tree-sitter parse",
     "test": "tree-sitter test",
     "test-windows": "tree-sitter test"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "tree-sitter": [
     {
-      "scope": "source.cpp",
+      "scope": "source.glsl",
       "file-types": [
         "vert",
         "frag",


### PR DESCRIPTION
Hi! I've included a few fixes/tweaks here, including:

* Use a semver range for `tree-sitter-c` instead of `git://..`. Git dependencies tend to be less reliable across different environments, and can slow down installs by requiring a relatively heavy git clone operation.
* Upgrade to the latest version of `tree-sitter-cli`, and add both `build` and `parse` scripts to the package.
* Use "scope.glsl" instead of "scope.cpp" in the `tree-sitter` field in package.json.
* Regenerate `src/parser.c` after making the above changes.

Thanks very much!